### PR TITLE
Added simple rspec coverage.

### DIFF
--- a/lib/kender/coverage.rb
+++ b/lib/kender/coverage.rb
@@ -1,0 +1,65 @@
+class Kender::Coverage
+  def initialize
+  end
+
+  def self.report
+    self.new.test
+  end
+
+  def code_files
+    return @code_files if @code_files
+    @code_files = `find app lib -type f -name "*.rb"`.split(/\n/)
+    @code_files.delete_if do |filename|
+      excluded = false
+      exclusions.each do |pattern|
+        if pattern.match(filename)
+          excluded = true; break
+        end
+      end
+      excluded
+    end
+  end
+
+  #TODO: needs to be per-app config.
+  def exclusions
+    [/^app\/admin/]
+  end
+  
+  def spec_files
+    @spec_files ||= `find spec -type f`.split(/\n/)
+  end
+  
+  def spec_file_for_code_file(code_filename)
+    pattern = Regexp.new(code_filename.split('/').last[0..-4])
+    spec_files.grep(pattern).first
+  end
+
+  def method_list
+    return @method_list if @method_list
+    @method_list = {}
+    code_files.each do |filename|
+      pattern = /^.* def ([^ \(]+).*$/
+      method_list[filename] = File.read(filename).split(/\n/).grep(pattern)
+      method_list[filename].map! { |method_signature| method_signature.gsub(pattern, '\1') }
+    end
+    @method_list
+  end
+  
+  def test
+    score, max_score = 0, 0
+    code_files.each do |filename|
+      max_score += method_list[filename].size # each methods count for one.
+      spec_file = spec_file_for_code_file(filename)
+      if spec_file && File.exist?(spec_file)
+        method_list[filename].each do |method_name|
+          score += 1 if `grep -rn "describe.*#{method_name}" #{spec_file}`.size > 0
+        end
+      else
+        puts "rspec file for #{filename} could not be found."
+      end
+    end
+    puts "Kender Code Coverage Report: #{score}/#{max_score}"
+  end
+end
+
+

--- a/lib/kender/tasks/ci.rake
+++ b/lib/kender/tasks/ci.rake
@@ -1,6 +1,7 @@
 require 'kender/configuration'
 require 'kender/github'
 require 'kender/command'
+require 'kender/coverage'
 
 # Helper method to call rake tasks without blowing up when they do not exists
 # @Return: false when it could not be executed or there was some error.
@@ -38,6 +39,7 @@ namespace :ci do
     Kender::Command.all.each do |command|
       command.execute
     end
+    Kender::Coverage.report
   end
 
   desc "Destroy resources created externally for the continuous integration run, e.g. drops databases"


### PR DESCRIPTION
After looking at Checkmate's code coverage https://github.com/mdsol/checkmate/pull/813

I found these number were misleadingly inflated. on the screenshot shown.
proxy_response which scores high 94.4% ... Why is that so, rspec detect that the code has ran. but it is simply used by another class for another spec (in this case, session_controller_rspec)

In fact, we had no spec for that file when those screenshot was taken.

so I thought for a simpler less smart alternative to calculate our code coverage.
very simple heuristic says
- for each ruby files you have, you should have an rspec file.
- for each methods you have, you should have a describe statement.
- I do not ignore private methods at this point.

here is the output for checkmate. ran through kender

```
rspec file for app/models/action/index_action.rb could not be found.
rspec file for app/models/action/show_action.rb could not be found.
rspec file for app/models/action/tailored_action.rb could not be found.
rspec file for app/validators/url_validator.rb could not be found.
rspec file for lib/checkmate/error/not_my_problem.rb could not be found.
rspec file for lib/checkmate/taggable_exceptions.rb could not be found.
rspec file for lib/mdsol/uri/prefix.rb could not be found.
rspec file for lib/paginatable.rb could not be found.
rspec file for lib/proxy_response.rb could not be found.
rspec file for lib/range_calculator.rb could not be found.
rspec file for lib/ui/selector_error.rb could not be found.
rspec file for lib/user_context.rb could not be found.
Kender Code Coverage Report: 21/192
```

I should make it a percent, but if we weight each method 1 point, that is 10.93% coverage

I am not taking account line numbers. and its probably not a bad thing since we aim at short methods.
