### PR TITLE
Adds 'cucucmber-rails' to list of gems that make kender run cucumber.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.2.6
+* Updated to check for cucumber-rails in addition to cucumber
+
 # 0.2.5
 * Updated to only check for gems explicitly declared in Gemfile
 

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -2,7 +2,7 @@ module Kender
   class Cucumber < Command
 
     def available?
-      in_gemfile?('cucumber') and not(ENV['VALIDATE_PROJECT'])
+      %w[cucumber cucumber-rails].any? { |gem| in_gemfile?(gem) } && !ENV['VALIDATE_PROJECT']
     end
 
     def command

--- a/lib/kender/version.rb
+++ b/lib/kender/version.rb
@@ -1,3 +1,3 @@
 module Kender
-  VERSION = '0.2.5'
+  VERSION = '0.2.6'
 end


### PR DESCRIPTION
The last Kender PR (https://github.com/mdsol/kender/pull/59) resulted in a situation where Kender does not execute `cucumber` when the rake task `ci:run` is invoked for the MCC Admin repo.  This is because the MCC Admin only explicitly contains `cucumber-rails` in it's `Gemfile`; we saw no reason to require `cucumber` as well.

This PR relaxes the condition for executing the `cucumber` command by requiring the presence of _either_ `cucumber` _or_ `cucumber-rails` in the `Gemfile`.

Personally, I would prefer to revert the above referenced PR, but others disagree.

**Testing Results**

After making the current develop branch of MCC Admin point to this branch:

```
mccadmin ecampbell$ bin/rake ci:list

Kender will execute the following software:
brakeman
rspec
cucumber
```

I regressed the existing scenarios as well:

```
7 scenarios (7 passed)
32 steps (32 passed)
1m34.283s
```
