### PR TITLE
Feature/config deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 script: bundle exec cucumber
 rvm:
   - 1.9.2
-  - 1.9.3-p327
   - 1.9.3-p545
   - 2.0.0
-  - 2.1.1
+  - 2.1.2
+  - ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: ruby
 script: bundle exec cucumber
 rvm:
-  - 1.9.2
   - 1.9.3-p545
   - 2.0.0
   - 2.1.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   without dice_bag so not need of supporting the ability of doing so.
   It is a backwards-incompatible change for those using their own
 config:all rake task.
+* Kender needs Ruby 1.9.3 or superior
 
 # 0.2.6
 * Updated to check for cucumber-rails in addition to cucumber

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 0.3.0
+* Use config:deploy instead of config:all rake task.
+  config:deploy will always overwrite every config file without asking.
+* Kender depends on dice_bag. Realistically probably noone was using it
+  without dice_bag so not need of supporting the ability of doing so.
+  It is a backwards-incompatible change for those using their own
+config:all rake task.
+
 # 0.2.2
 * Adds support for i18n-tasks gem.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add the following to your `Gemfile`:
 
 ```ruby
 group :development, :test do
-  gem 'kender', :git => 'git@github.com:mdsol/kender.git'
+  gem 'kender', '~> 0.3'
 end
 ```
 
@@ -38,21 +38,15 @@ Kender-based CI runs are executed using the `ci` rake task. The following rake
 tasks defined locally in your project will be run at the appropriate point in
 the process if they exist:
 
-* `config:all`
+* `config:deploy`
 * `db:migrate`
 * `db:create`
 * `db:drop`
 
-To create `config:all` we strongly recommend you use Kender's companion
-[DiceBag][db] gem:
-
-```ruby
-gem 'dice_bag', '~> 0.7'
-```
+`config:deploy` is defined in the [DiceBag][db] gem.
+It will always overwrite the configuration files with the values in the templates.
 
 [db]: https://github.com/mdsol/dice_bag
-
-Unlike Kender, DiceBag is intended for use in all stages, including production.
 
 The `db` tasks are assumed to work like those found in Rails.
 

--- a/kender.gemspec
+++ b/kender.gemspec
@@ -7,7 +7,9 @@ Gem::Specification.new do |s|
 
   s.authors = ['Andrew Smith', 'Jordi Polo']
   s.email = ['asmith@mdsol.com', 'jcarres@mdsol.com']
-  s.summary = 'Kender is a library of rake tasks that provides a consistent framework for continuous integration (CI).'
+  s.summary = 'Rake tasks for continuous integration (CI).'
+  s.description = 'Kender is a library of rake tasks that provides a consistent framework for continuous integration (CI).'
+  s.homepage = "https://github.com/mdsol/kender"
   s.license = 'MIT'
 
   s.files = Dir['lib/**/*']
@@ -15,7 +17,8 @@ Gem::Specification.new do |s|
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'bundler'
-  s.add_development_dependency 'aruba', '~> 0.5.4'
-  s.add_development_dependency 'rake'
+  s.add_dependency 'bundler', '~> 0'
+  s.add_dependency 'dice_bag', '~> 0.8'
+  s.add_development_dependency 'aruba', '~> 0.5'
+  s.add_development_dependency 'rake', '~> 0'
 end

--- a/kender.gemspec
+++ b/kender.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.executables = Dir['bin/*'].map{ |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.add_dependency 'bundler', '~> 0'
+  s.add_dependency 'bundler'
   s.add_dependency 'dice_bag', '~> 0.8'
   s.add_development_dependency 'aruba', '~> 0.5'
   s.add_development_dependency 'rake', '~> 0'

--- a/lib/kender/tasks/ci.rake
+++ b/lib/kender/tasks/ci.rake
@@ -29,7 +29,7 @@ end
 namespace :ci do
 
   # UI for the user, these are tasks the user can use
-  desc "Configure the app to run continuous integration tests"
+  desc "Configure the app to run continuous integration tests."
   task :config => ['ci:env', 'ci:config_project', 'ci:setup_db']
 
   desc "Run continuous integration tests with the current configuration"
@@ -63,7 +63,7 @@ namespace :ci do
   end
 
   task :config_project do
-    unless run_successfully?('config:all')
+    unless run_successfully?('config:deploy')
       puts 'Your project could not be configured, a config:all task needed. Consider installing dice_bag'
     end
   end

--- a/lib/kender/version.rb
+++ b/lib/kender/version.rb
@@ -1,3 +1,3 @@
 module Kender
-  VERSION = '0.2.2'
+  VERSION = '0.3.0'
 end


### PR DESCRIPTION
@pmavinkurve-mdsol 

Using config:deploy isntead of config:all
The difference between these two tasks is that config:deploy do not ask questions and will overwrite always. It is used by Chef.
I think that's what we want in the CI also, i.e. all automatic uses of dice_bag should use deploy to avoid the problem of stalling the process waiting for input.

The rest of the changes are improvements in docs and gemfile

