### PR TITLE
jasmine can work without the phantom gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.3.1
+* Allow Jasmine to run even when Jasmine-phantom is not in the Gemfile
+
 # 0.3.0
 * Use config:deploy instead of config:all rake task.
   config:deploy will always overwrite every config file without asking.

--- a/lib/kender/commands/jasmine.rb
+++ b/lib/kender/commands/jasmine.rb
@@ -8,9 +8,9 @@ module Kender
       return false if ENV['VALIDATE_PROJECT']
 
       # make sure those gems were added
-      return false unless in_gemfile?("jasmine") && in_gemfile?("jasmine-phantom")
+      return false unless in_gemfile?("jasmine")
 
-      # verify jasmine and phantomjs are present
+      # verify jasmine and phantomjs are both present
       `phantomjs --version 2>&1 > /dev/null`
       return false unless $?.success?
       `bundle exec jasmine license`
@@ -18,7 +18,12 @@ module Kender
     end
 
     def command
-      'bundle exec rake jasmine:phantom:ci'
+      if in_gemfile?("jasmine-phantom")
+        #This is nicer as will install phantomJS for us.
+        'bundle exec rake jasmine:phantom:ci'
+      else
+        'bundle exec rake jasmine:ci'
+      end
     end
 
   end

--- a/lib/kender/version.rb
+++ b/lib/kender/version.rb
@@ -1,3 +1,3 @@
 module Kender
-  VERSION = '0.3.0'
+  VERSION = '0.3.1'
 end


### PR DESCRIPTION
We were not running Jasmine in Angelfire because we were requiring jasmine-phantom to run it but it is not necessary if phantom is already installed.

@BPONTES  onegaishimaasu