### PR TITLE
Add support for knapsack gem when running cucumber scenarios and rspecs on travis-ci

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.0
+* knapsack support (https://github.com/ArturT/knapsack)
+
 # 0.5.0
 * Removes functionality regarding Github
 * Adds ci:fail_fast task to allow CI to finish at the first failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.6.0
-* knapsack support (https://github.com/ArturT/knapsack)
+* knapsack support for cucumber (https://github.com/ArturT/knapsack)
 
 # 0.5.0
 * Removes functionality regarding Github

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # 0.6.0
-* knapsack support for cucumber (https://github.com/ArturT/knapsack)
+* knapsack support for cucumber and rspec (https://github.com/ArturT/knapsack)
 
 # 0.5.0
 * Removes functionality regarding Github

--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ The [RSpec][r] specs will be run. No command-line parameters or switches are
 passed, so ensure your defaults in `.rspec` are correct for a CI run. If the
 rspec command fails, the CI run will fail.
 
+Rspecs can be spread across multiple nodes by using using the following gems:
+- [knapsack](https://github.com/ArturT/knapsack)
+  - The following environment variables must be accessible when using travis-ci:
+    - CI_NODE_TOTAL
+    - CI_NODE_INDEX
+
 [r]: https://github.com/rspec/rspec
 
 #### Jasmine

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ to use a specific browser as part of the CI run. You can set the environment
 variable `HEADED_BROWSER` to the name of the browser you want to run. Verify your project
 can use the `HEADED_BROWSER` environment variable.
 
+Cucumber scenarios can be spread across multiple nodes by using using the following gems:
+- [knapsack](https://github.com/ArturT/knapsack)
+  - The following environment variables must be accessible when using travis-ci:
+    - CI_NODE_TOTAL
+    - CI_NODE_INDEX
+- [parallel_tests](https://github.com/grosser/parallel_tests)
+
 [c]: https://github.com/cucumber/cucumber
 
 #### RSpec

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,13 +8,10 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        puts "starting Knapsack!"
         "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
-        puts "starting ParallelTests!"
         "#{extra_env} bundle exec rake parallel:features"
       else
-        puts "starting cucumber!"
         "#{extra_env} bundle exec cucumber"
       end
     end

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -7,7 +7,9 @@ module Kender
 
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
-      if defined?(ParallelTests)
+      if defined?(Knapsack)
+        "#{extra_env} bundle exec rake knapsack:cucumber"
+      elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"
       else
         "#{extra_env} bundle exec cucumber"

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,7 +8,8 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
+        knapsack_env = "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']}"
+        "#{extra_env} #{knapsack_env} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"
       else

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,18 +8,12 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        Rails.logger.error "starting Knapsack!"
-        Rails.logger.info "starting Knapsack!"
         puts "starting Knapsack!"
         "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
-        Rails.logger.error "starting ParallelTests!"
-        Rails.logger.info "starting ParallelTests!"
         puts "starting ParallelTests!"
         "#{extra_env} bundle exec rake parallel:features"
       else
-        Rails.logger.error "starting cucumber!"
-        Rails.logger.info "starting cucumber!"
         puts "starting cucumber!"
         "#{extra_env} bundle exec cucumber"
       end

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,10 +8,10 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        # Rails.logger.error "starting knapsack!"
-        # Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
-        # Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
-        # "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
+        Rails.logger.error "starting knapsack!"
+        Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
+        Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
+        "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"
       else

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,13 +8,19 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        Rails.logger.error "starting knapsack!"
-        Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
-        Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
+        Rails.logger.error "starting Knapsack!"
+        Rails.logger.info "starting Knapsack!"
+        puts "starting Knapsack!"
         "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
+        Rails.logger.error "starting ParallelTests!"
+        Rails.logger.info "starting ParallelTests!"
+        puts "starting ParallelTests!"
         "#{extra_env} bundle exec rake parallel:features"
       else
+        Rails.logger.error "starting cucumber!"
+        Rails.logger.info "starting cucumber!"
+        puts "starting cucumber!"
         "#{extra_env} bundle exec cucumber"
       end
     end

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,10 +8,10 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        Rails.logger.error "starting knapsack!"
-        Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
-        Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
-        "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
+        # Rails.logger.error "starting knapsack!"
+        # Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
+        # Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
+        # "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"
       else

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,6 +8,9 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
+        puts "starting knapsack!"
+        puts "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
+        puts "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
         "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,9 +8,9 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        puts "starting knapsack!"
-        puts "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
-        puts "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
+        Rails.logger.error "starting knapsack!"
+        Rails.logger.error "ENV['CI_NODE_TOTAL']: #{ENV['CI_NODE_TOTAL']}"
+        Rails.logger.error "ENV['CI_NODE_INDEX']: #{ENV['CI_NODE_INDEX']}"
         "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"

--- a/lib/kender/commands/cucumber.rb
+++ b/lib/kender/commands/cucumber.rb
@@ -8,7 +8,7 @@ module Kender
     def command
       extra_env = ENV['HEADED_BROWSER'] ? "HEADED_BROWSER=#{ENV['HEADED_BROWSER']}" : ''
       if defined?(Knapsack)
-        "#{extra_env} bundle exec rake knapsack:cucumber"
+        "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']} bundle exec rake knapsack:cucumber"
       elsif defined?(ParallelTests)
         "#{extra_env} bundle exec rake parallel:features"
       else

--- a/lib/kender/commands/rspec.rb
+++ b/lib/kender/commands/rspec.rb
@@ -8,7 +8,10 @@ module Kender
     end
 
     def command
-      if defined?(ParallelTests)
+      if defined?(Knapsack)
+        knapsack_env = "CI_NODE_TOTAL=#{ENV['CI_NODE_TOTAL']} CI_NODE_INDEX=#{ENV['CI_NODE_INDEX']}"
+        "#{knapsack_env} bundle exec rake knapsack:rspec"
+      elsif defined?(ParallelTests)
         'bundle exec rake parallel:spec'
       else
         'bundle exec rspec'

--- a/lib/kender/version.rb
+++ b/lib/kender/version.rb
@@ -1,3 +1,3 @@
 module Kender
-  VERSION = '0.5.0'.freeze
+  VERSION = '0.6.0'.freeze
 end


### PR DESCRIPTION
A few projects have adopted using the [knapsack gem](https://github.com/ArturT/knapsack) to split up running cucumber feature scenarios across several travis-ci nodes. 

Adding support for the gem in kender.