### PR TITLE
Only use schema load for Rails version <5

### DIFF
--- a/lib/kender/tasks/ci.rake
+++ b/lib/kender/tasks/ci.rake
@@ -83,13 +83,15 @@ namespace :ci do
   task :setup_db do
     if Rake::Task.task_defined?('db:create')
       if !defined?(ParallelTests)
-        # Use db:schema:load instead of db:migrate because of this issue
-        # https://github.com/rails/rails/issues/19001
-        db_task = if File.exist?('db/schema.rb')
-          'db:schema:load'
-        else
-          'db:migrate'
-        end
+        db_task = if defined?(Rails) && Rails::VERSION::MAJOR < 5 && File.exist?('db/schema.rb')
+                    # Use db:schema:load instead of db:migrate for Rails 4
+                    # because of this issue
+                    # https://github.com/rails/rails/issues/19001
+                    'db:schema:load'
+                  else
+                    'db:migrate'
+                  end
+
         unless run_successfully?(['db:create', db_task])
           puts 'The DB could not be set up successfully.'
         end


### PR DESCRIPTION
Hi folks,

This PR updates the workaround in `ci:setup_db` to address [this Rails 4 issue](https://github.com/rails/rails/issues/19001).

This change can cause a problem in CI: if there is a database migration that _doesn't_ change `schema.rb`, the database won't be in the correct state during CI.

This came up in https://github.com/mdsol/dalton/pull/3269, where we've written a migration to create database views that aren't reflected in the Rails schema. We're working around it by manually running the tasks in `ci:config` in the `travis.yml`, replacing `db:schema:load` with `db:migrate`. 

I'm not really sure how kender updates work, but i just wanted to get the ball rolling by submitting a PR. 

