### PR TITLE
Remove reference to undefined var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.2
+* Prevent obscure error message (undefined method) when ci:run task aborts
+
 # 0.6.1
 * Fix for the ci:run task (when used individually) to abort after test failures.
 

--- a/lib/kender/tasks/ci.rake
+++ b/lib/kender/tasks/ci.rake
@@ -46,7 +46,7 @@ namespace :ci do
     Kender::Command.all.each do |command|
       puts "#{command.name} failed" unless command.success
     end
-    abort "Command failed: #{command}" unless Kender::Command.all_success?
+    abort "Command(s) failed" unless Kender::Command.all_success?
   end
 
 

--- a/lib/kender/version.rb
+++ b/lib/kender/version.rb
@@ -1,3 +1,3 @@
 module Kender
-  VERSION = '0.6.1'.freeze
+  VERSION = '0.6.2'.freeze
 end


### PR DESCRIPTION
Prevent generation of this error when a CI step fails during the `ci:run` task:
```
rake aborted!
NameError: undefined local variable or method `command' for main:Object
/home/travis/build/mdsol/study_app_authorizer/vendor/bundle/ruby/2.7.0/bundler/gems/kender-a6892a47ea4c/lib/kender/tasks/ci.rake:49:in `block (2 levels) in <main>'
/home/travis/build/mdsol/study_app_authorizer/vendor/bundle/ruby/2.7.0/gems/rake-13.0.6/exe/rake:27:in `<top (required)>'
/home/travis/.rvm/gems/ruby-2.7.2/gems/bundler-2.1.4/lib/bundler/cli/exec.rb:63:in `load'
```